### PR TITLE
add binding_of_caller for better_errors

### DIFF
--- a/spawnpoint.rb
+++ b/spawnpoint.rb
@@ -32,6 +32,7 @@ group :development do
   gem "spring"
   gem "quiet_assets"
   gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :development, :test do


### PR DESCRIPTION
Hey there,

This PR adds the binding_of_caller gem for use with better_errors. Advanced features of better_errors (REPL, local/instance variable inspection, pretty stack frame names) requires this gem, and nearly everyone uses it so that their error pages can really :sparkles:.
